### PR TITLE
Add members from a list of addresses from the clipboard

### DIFF
--- a/packages/react-app/src/views/Create.jsx
+++ b/packages/react-app/src/views/Create.jsx
@@ -289,6 +289,26 @@ export default function Create({
 
   const Step2 = () => {
     const [toAddress, setToAddress] = useState("");
+
+    const handleAddVoters = async () => {
+      const text = await navigator.clipboard.readText();
+      const addresses = text.split(",");
+
+      const candidates = newElection.candidates.slice();
+
+      addresses.forEach(voteAddress => {
+        try {
+          const voteAddressWithChecksum = ethers.utils.getAddress(voteAddress);
+          if (!candidates.includes(voteAddressWithChecksum)) {
+            candidates.push(voteAddressWithChecksum);
+          }
+        } catch (error) {
+          console.log(error);
+        }
+      });
+      newElection.candidates = candidates;
+    };
+
     return (
       <>
         <Form
@@ -309,6 +329,10 @@ export default function Create({
               },
             ]}
           >
+            <Button type="primary" block onClick={() => handleAddVoters()}>
+              Add Candidates from Clipboard
+            </Button>
+
             <Space style={{ margin: "1em 0em" }}>
               <AddAddress
                 ensProvider={mainnetProvider}


### PR DESCRIPTION
When creating a new election, on the Add Candidates step, you can add a list of comma separated addresses pasted in the clipboard (as the one you can copy from a Tip Party) and populate the candidates automatically.

We should improve the button!

![candidates](https://user-images.githubusercontent.com/466652/136082135-1503d83c-3995-4140-b2a5-f5f0c017c076.png)

