### PR TITLE
Add metatx contracts

### DIFF
--- a/packages/hardhat/contracts/Diplomat.sol
+++ b/packages/hardhat/contracts/Diplomat.sol
@@ -36,8 +36,9 @@ pragma solidity ^0.8.9;
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./ElectionFactory.sol";
+import "./EIP712MetaTransaction.sol";
 
-contract Diplomat is AccessControl, ElectionFactory {
+contract Diplomat is AccessControl, ElectionFactory, EIP712MetaTransaction("Diplomat", "1") {
 
     bytes32 public constant VOTER_ROLE = 
         keccak256("VOTER_ROLE");

--- a/packages/hardhat/contracts/EIP712Base.sol
+++ b/packages/hardhat/contracts/EIP712Base.sol
@@ -1,0 +1,48 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+contract EIP712Base {
+
+    struct EIP712Domain {
+        string name;
+        string version;
+        address verifyingContract;
+        bytes32 salt;
+    }
+
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH = keccak256(bytes("EIP712Domain(string name,string version,address verifyingContract,bytes32 salt)"));
+
+    bytes32 internal domainSeparator;
+
+    constructor(string memory name, string memory version) {
+        domainSeparator = keccak256(abi.encode(
+            EIP712_DOMAIN_TYPEHASH,
+            keccak256(bytes(name)),
+            keccak256(bytes(version)),
+            address(this),
+            bytes32(getChainID())
+        ));
+    }
+
+    function getChainID() internal view returns (uint256 id) {
+        assembly {
+            id := chainid()
+        }
+    }
+
+    function getDomainSeparator() private view returns(bytes32) {
+        return domainSeparator;
+    }
+
+    /**
+    * Accept message hash and returns hash message in EIP712 compatible form
+    * So that it can be used to recover signer from signature signed using EIP712 formatted data
+    * https://eips.ethereum.org/EIPS/eip-712
+    * "\\x19" makes the encoding deterministic
+    * "\\x01" is the version byte to make it compatible to EIP-191
+    */
+    function toTypedMessageHash(bytes32 messageHash) internal view returns(bytes32) {
+        return keccak256(abi.encodePacked("\x19\x01", getDomainSeparator(), messageHash));
+    }
+
+}

--- a/packages/hardhat/contracts/EIP712MetaTransaction.sol
+++ b/packages/hardhat/contracts/EIP712MetaTransaction.sol
@@ -1,0 +1,86 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "./EIP712Base.sol";
+
+contract EIP712MetaTransaction is EIP712Base {
+    bytes32 private constant META_TRANSACTION_TYPEHASH = keccak256(bytes("MetaTransaction(uint256 nonce,address from,bytes functionSignature)"));
+
+    event MetaTransactionExecuted(address userAddress, address payable relayerAddress, bytes functionSignature);
+    mapping(address => uint256) private nonces;
+
+    /*
+     * Meta transaction structure.
+     * No point of including value field here as if user is doing value transfer then he has the funds to pay for gas
+     * He should call the desired function directly in that case.
+     */
+    struct MetaTransaction {
+        uint256 nonce;
+        address from;
+        bytes functionSignature;
+    }
+
+    constructor(string memory name, string memory version) EIP712Base(name, version) {}
+
+    function convertBytesToBytes4(bytes memory inBytes) internal pure returns (bytes4 outBytes4) {
+        if (inBytes.length == 0) {
+            return 0x0;
+        }
+
+        assembly {
+            outBytes4 := mload(add(inBytes, 32))
+        }
+    }
+
+    function executeMetaTransaction(address userAddress,
+        bytes memory functionSignature, bytes32 sigR, bytes32 sigS, uint8 sigV) public payable returns(bytes memory) {
+        bytes4 destinationFunctionSig = convertBytesToBytes4(functionSignature);
+        require(destinationFunctionSig != msg.sig, "functionSignature can not be of executeMetaTransaction method");
+        MetaTransaction memory metaTx = MetaTransaction({
+            nonce: nonces[userAddress],
+            from: userAddress,
+            functionSignature: functionSignature
+        });
+        require(verify(userAddress, metaTx, sigR, sigS, sigV), "Signer and signature do not match");
+        nonces[userAddress]++;
+        // Append userAddress at the end to extract it from calling context
+        (bool success, bytes memory returnData) = address(this).call(abi.encodePacked(functionSignature, userAddress));
+
+        require(success, "Function call not successful");
+        emit MetaTransactionExecuted(userAddress, payable(msg.sender), functionSignature);
+        return returnData;
+    }
+
+    function hashMetaTransaction(MetaTransaction memory metaTx) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            META_TRANSACTION_TYPEHASH,
+            metaTx.nonce,
+            metaTx.from,
+            keccak256(metaTx.functionSignature)
+        ));
+    }
+
+    function getNonce(address user) external view returns(uint256 nonce) {
+        nonce = nonces[user];
+    }
+
+    function verify(address user, MetaTransaction memory metaTx, bytes32 sigR, bytes32 sigS, uint8 sigV) internal view returns (bool) {
+        address signer = ecrecover(toTypedMessageHash(hashMetaTransaction(metaTx)), sigV, sigR, sigS);
+        require(signer != address(0), "Invalid signature");
+        return signer == user;
+    }
+
+    function msgSender() internal view returns(address sender) {
+        if(msg.sender == address(this)) {
+            bytes memory array = msg.data;
+            uint256 index = msg.data.length;
+            assembly {
+                // Load the 32 bytes word from memory with the address on the lower 20 bytes, and mask those.
+                sender := and(mload(add(array, index)), 0xffffffffffffffffffffffffffffffffffffffff)
+            }
+        } else {
+            sender = msg.sender;
+        }
+        return sender;
+    }
+}


### PR DESCRIPTION
Sets the base for future metatx usage (can also be integrated with signature and Ceramic versions)