### PR TITLE
Add candidates from CSV file

### DIFF
--- a/packages/react-app/src/views/Create.jsx
+++ b/packages/react-app/src/views/Create.jsx
@@ -1,5 +1,5 @@
 import { ChevronLeftIcon, CopyIcon, AddIcon, DeleteIcon, CheckIcon } from "@chakra-ui/icons";
-import { MdContentPaste } from "react-icons/md";
+import { MdContentPaste, MdFilePresent } from "react-icons/md";
 import {
   Box,
   Button,
@@ -29,6 +29,7 @@ import {
   Select,
   Spinner,
   IconButton,
+  Icon,
   Checkbox,
 } from "@chakra-ui/react";
 import React, { useEffect, useState } from "react";
@@ -303,6 +304,37 @@ const Create = ({
     setToAddress("");
   };
 
+  const handleAddVotersFromCsv = async event => {
+    if (event.target.files.length > 0) {
+      const file = event.target.files[0];
+      if (file.type != "text/csv") {
+        return;
+      }
+
+      let reader = new FileReader();
+
+      reader.onload = function (e) {
+        const addresses = e.target.result.split(",");
+
+        addresses.forEach(voteAddress => {
+          try {
+            const voteAddressWithChecksum = ethers.utils.getAddress(voteAddress);
+            if (!newElection.voters.includes(voteAddressWithChecksum)) {
+              newElection.voters.push(voteAddressWithChecksum);
+            }
+          } catch (error) {
+            console.log(error);
+          }
+        });
+
+        setToAddress(" ");
+        setToAddress("");
+      };
+
+      reader.readAsText(file);
+    }
+  };
+
   const addCandidates = async () => {
     if (!newElection.candidates.includes(toAddress)) {
       newElection.candidates.push(toAddress);
@@ -450,6 +482,23 @@ const Create = ({
                       />
                     </Tooltip>
                   )}
+                  <Tooltip label="Add from CSV file">
+                    <label for="csvFile" style={{ display: "inline-flex", paddingTop: 10, cursor: "pointer" }}>
+                      <Icon
+                        aria-label="Add from CSV file"
+                        as={MdFilePresent}
+                        variant="ghost"
+                        style={{ width: 18, height: 18 }}
+                      />
+                    </label>
+                  </Tooltip>
+                  <input
+                    type="file"
+                    id="csvFile"
+                    name="csvFile"
+                    style={{ display: "none" }}
+                    onChange={(evt) => handleAddVotersFromCsv(evt)}
+                  />
                 </InputGroup>
               </HStack>
               <Box


### PR DESCRIPTION
Add a file icon to the right of the Copy From Clipboard icon to add candidates from a CSV file (useful to import a CSV exported from TipParty).

When the icon is clicked, a browse file is shown and, if the user select a csv file, the addresses are imported as candidates.

![localhost_3000_create](https://user-images.githubusercontent.com/466652/142066419-a02195ed-c3cd-4da4-b75d-d596201524cc.png)


