### PR TITLE
Add additional wallet support

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -212,6 +212,7 @@ function App(props) {
           { walletName: "metamask" },
           { walletName: "gnosis" },
           { walletName: "walletConnect", infuraKey: INFURA_ID },
+          { walletName: "tally" }
         ],
       },
       subscriptions: {


### PR DESCRIPTION
Add support for [Tally](https://tally.cash/) wallet. Tally is an open-source browser extension similar to Metamask.